### PR TITLE
change usage regex to allow non decimal number 

### DIFF
--- a/src/Isp/Videotron.php
+++ b/src/Isp/Videotron.php
@@ -17,7 +17,7 @@ final class Videotron implements InternetServiceProvider
     const REGEX_PERIOD = '/Usage from\s+(.*?) to\s+(.+),/';
 
     // Captures 24.4 and 130 from "24.4 / 130 GB"
-    const REGEX_USAGE = '/(\d+(?:.{0,1}\d+)) \/ (\d+(?:.{0,1}\d+))/';
+    const REGEX_USAGE = '/(\d+(?:.\d+)?) \/ (\d+(?:.\d+)?)/';
 
     /**
      * @var Client

--- a/src/Isp/Videotron.php
+++ b/src/Isp/Videotron.php
@@ -17,7 +17,7 @@ final class Videotron implements InternetServiceProvider
     const REGEX_PERIOD = '/Usage from\s+(.*?) to\s+(.+),/';
 
     // Captures 24.4 and 130 from "24.4 / 130 GB"
-    const REGEX_USAGE = '/(\d+(?:.\d+)) \/ (\d+(?:.\d+))/';
+    const REGEX_USAGE = '/(\d+(?:.{0,1}\d+)) \/ (\d+(?:.{0,1}\d+))/';
 
     /**
      * @var Client


### PR DESCRIPTION
In my case,  the result for "29 / 130 Go" was not working and only fail with some errors and warnings. So, I found that was because of the non-decimal first number.
